### PR TITLE
Wrong case used

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ const getConfig = require("vuepress-bar");
 
 module.exports = {
   themeConfig: {
-    ...getConfig(`${__dirName}/..`)
+    ...getConfig(`${__dirname}/..`)
   }
 };
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const markdownIt = require("markdown-it");
 const meta = require("markdown-it-meta");
 const { lstatSync, readdirSync, readFileSync, existsSync } = require("fs");
 const { join, normalize, sep } = require("path");
-const startCase = require("lodash.startCase");
+const startCase = require("lodash.startcase");
 const escapeRegExp = require("lodash.escaperegexp");
 
 const isDirectory = source => lstatSync(source).isDirectory();


### PR DESCRIPTION
### See:
- https://www.npmjs.com/package/lodash.startcase
- https://nodejs.org/docs/latest/api/globals.html#globals_dirname


### Fixes:
- Error: Cannot find module 'lodash.startCase'
- ReferenceError: __dirName is not defined