### PR TITLE
Adjusted the nav link separator to work also on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,7 @@ function nav(rootDir, { navPrefix, stripNumbers, skipEmptyNavbar }, relativeDir 
         );
       }
     }
-    result = { text: getName(baseDir, { stripNumbers, navPrefix }), link: relativeDir + sep };
+    result = { text: getName(baseDir, { stripNumbers, navPrefix }), link: relativeDir.replace('\\','/') + '/' };
   } else if (childrenDirs.length > 0) {
     const items = childrenDirs
       .map(subDir => nav(rootDir, options, join(relativeDir, subDir), currentNavLevel + 1))


### PR DESCRIPTION
I'm proposing a solution to #2 which I opened. I used a normal replace to fix the Windows separator `\` with the `/` character in the `nav` links.

