### PR TITLE
fix error on folder without any md file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,9 +125,11 @@ function side(
         );
         if (children.length > 0 || !skipEmptySidebar) {
           // Where to put '02-folder' in ['01-file', { title: 'Other Folder', children: ['03-folder/file'] }]
-          const sortedFolderPosition = fileLinks.findIndex(
-            link => subDir < (link.children ? (link.children[0] || "").split(sep)[0] : link)
-          );
+          const sortedFolderPosition = fileLinks.findIndex(link => {
+            const title = (link.children && link.children[0]) || "";
+            return subDir < (typeof title === "string" ? title.split(sep)[0] : link);
+          });
+          
           const insertPosition =
             mixDirectoriesAndFilesAlphabetically && sortedFolderPosition > -1 ? sortedFolderPosition : fileLinks.length;
 


### PR DESCRIPTION
if a directory only has subdirectories, a TypeError `(link.children[0] || "").split is not a function` was raised